### PR TITLE
Fixed website URL field validation

### DIFF
--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -1,13 +1,21 @@
 class Experience < ApplicationRecord
+  before_validation :check_website_url, if: :website_url?
   DESCRIPTION_MAX_LENGTH = 1000
 
   belongs_to :cv
   validates :company, :title, presence: true
   validates :description, length: { maximum: DESCRIPTION_MAX_LENGTH }
-  validates :website_url, format: { with: %r{\A(http|https)://[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]
+  validates :website_url, format: { with: %r{[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]
                                           {2,63}(:[0-9]{1,5})?(/.*)?\z}ix,
                                     message: 'is invalid' }, allow_blank: true
 
   scope :chronological_order, -> { order('ended_on IS NULL DESC, ended_on DESC, started_on DESC') }
   scope :by_position, -> { order('position') }
+
+  private
+
+  def check_website_url
+    self.website_url = website_url.squish.strip.downcase
+    self.website_url = "http://#{website_url}" unless website_url.start_with?('http')
+  end
 end

--- a/test/models/experience_test.rb
+++ b/test/models/experience_test.rb
@@ -19,4 +19,11 @@ class ExperienceTest < ActiveSupport::TestCase
     @experience.website_url = '.mydomain'
     assert_not @experience.valid?
   end
+  
+
+  test 'website protocol is automatically added' do
+    @experience.website_url = 'mydomain.tld'
+    assert @experience.valid?
+    assert @experience.website_url.start_with?('http')
+  end
 end

--- a/test/models/experience_test.rb
+++ b/test/models/experience_test.rb
@@ -19,7 +19,6 @@ class ExperienceTest < ActiveSupport::TestCase
     @experience.website_url = '.mydomain'
     assert_not @experience.valid?
   end
-  
 
   test 'website protocol is automatically added' do
     @experience.website_url = 'mydomain.tld'

--- a/test/models/experience_test.rb
+++ b/test/models/experience_test.rb
@@ -16,7 +16,7 @@ class ExperienceTest < ActiveSupport::TestCase
   end
 
   test 'website url should be valid' do
-    @experience.website_url = 'http://.mydomain.com'
+    @experience.website_url = '.mydomain'
     assert_not @experience.valid?
   end
 end


### PR DESCRIPTION
Updated the existing validation so that user can add the website link easily without adding the http/https. #181 

https://user-images.githubusercontent.com/81285549/129315523-bfc9a75f-959a-490d-9336-24f699b2d236.mp4

