### PR TITLE
Disabled publish button

### DIFF
--- a/app/javascript/src/javascripts/custom.js
+++ b/app/javascript/src/javascripts/custom.js
@@ -77,3 +77,10 @@ document.addEventListener('turbolinks:load', () => {
       return send.apply(this, arguments)
     }
 })()
+
+// Used to initialize tooltip on CV show page
+$(function () {
+  $('[data-placement="top"]').tooltip({
+    html: true
+  })
+})

--- a/app/views/cvs/_cv_controls.html.erb
+++ b/app/views/cvs/_cv_controls.html.erb
@@ -2,12 +2,18 @@
   <div class="container">
     <div class="d-flex align-items-center justify-content-center py-2 border-md-0 w-100">
       <% if @cv_edit_controls %> <!-- When CV owner is in edit mode ====== -->
-        <%= link_to 'Preview', cv_section_path(current_user.subdomain, preview: 't'), class: 'btn btn-primary mx-2' %>
+        <%= link_to 'Preview', cv_section_path(current_user.subdomain, preview: 't'), class: 'btn btn-primary' %>
 
         <% if @cv.published? %>
-          <%= link_to 'Unpublish', cv_path("cv[published]" => "0"), method: :put, class: 'btn btn-outline-primary mx-2' %>
+          <%= link_to 'Unpublish', cv_path("cv[published]" => "0"), method: :put, class: 'btn btn-outline-primary mx-3' %>
         <% else %>
-          <%= link_to 'Publish', cv_path("cv[published]" => "1"), method: :put, class: 'btn btn-outline-primary mx-2' %>
+          <% if current_user.confirmed? %>
+            <%= link_to 'Publish', cv_path("cv[published]" => "1"), method: :put, class: 'btn btn-outline-primary mx-3' %>
+          <% else %>
+            <button class="btn btn-outline-primary mx-3 disabled" data-toggle="tooltip" data-placement="top" title="<%= t('tooltips.buttons.publish') %>">
+              Publish
+            </button>
+          <% end %>
         <% end %>
 
         <div class="dropdown dropup">

--- a/app/views/cvs/_cv_controls.html.erb
+++ b/app/views/cvs/_cv_controls.html.erb
@@ -10,9 +10,9 @@
           <% if current_user.confirmed? %>
             <%= link_to 'Publish', cv_path("cv[published]" => "1"), method: :put, class: 'btn btn-outline-primary mx-3' %>
           <% else %>
-            <button class="btn btn-outline-primary mx-3 disabled" data-toggle="tooltip" data-placement="top" title="<%= t('tooltips.buttons.publish') %>">
-              Publish
-            </button>
+            <%= button_tag 'Publish', class: 'btn btn-outline-primary mx-3 disabled',
+                                      data: {toggle: 'tooltip', placement: 'top'},
+                                      title: t('tooltips.buttons.publish', url: new_user_confirmation_path)  %>
           <% end %>
         <% end %>
 

--- a/config/locales/tooltips.en.yml
+++ b/config/locales/tooltips.en.yml
@@ -9,4 +9,4 @@ en:
       interests: 'Short description of both your job-related and job-unrelated interests.'
       future_plans: 'What would you want to accomplish in the next 3 years, from a professional perspective?'
     buttons:
-      publish: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='%{url}'>here</a> to confirm</span>"
+      publish_html: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='%{url}'>here</a> to confirm</span>"

--- a/config/locales/tooltips.en.yml
+++ b/config/locales/tooltips.en.yml
@@ -9,4 +9,4 @@ en:
       interests: 'Short description of both your job-related and job-unrelated interests.'
       future_plans: 'What would you want to accomplish in the next 3 years, from a professional perspective?'
     buttons:
-      publish: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='/users/confirmation/new'>here</a> to confirm</span>"
+      publish: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='%{url}'>here</a> to confirm</span>"

--- a/config/locales/tooltips.en.yml
+++ b/config/locales/tooltips.en.yml
@@ -8,3 +8,5 @@ en:
     extras:
       interests: 'Short description of both your job-related and job-unrelated interests.'
       future_plans: 'What would you want to accomplish in the next 3 years, from a professional perspective?'
+    buttons:
+      publish: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='/users/confirmation/new'>here</a> to confirm</span>"

--- a/config/locales/tooltips.it.yml
+++ b/config/locales/tooltips.it.yml
@@ -9,4 +9,4 @@ it:
       interests: 'Breve descrizione sui tuoi interessi lavorativi ed extra-lavorativi.'
       future_plans: 'Cosa vuoi realizzare e dove/come vorresti essere fra 3 anni?'
     buttons:
-      publish: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='%{url}'>here</a> to confirm</span>"
+      publish_html: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='%{url}'>here</a> to confirm</span>"

--- a/config/locales/tooltips.it.yml
+++ b/config/locales/tooltips.it.yml
@@ -9,4 +9,4 @@ it:
       interests: 'Breve descrizione sui tuoi interessi lavorativi ed extra-lavorativi.'
       future_plans: 'Cosa vuoi realizzare e dove/come vorresti essere fra 3 anni?'
     buttons:
-      publish: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='/users/confirmation/new'>here</a> to confirm</span>"
+      publish: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='%{url}'>here</a> to confirm</span>"

--- a/config/locales/tooltips.it.yml
+++ b/config/locales/tooltips.it.yml
@@ -8,3 +8,5 @@ it:
     extras:
       interests: 'Breve descrizione sui tuoi interessi lavorativi ed extra-lavorativi.'
       future_plans: 'Cosa vuoi realizzare e dove/come vorresti essere fra 3 anni?'
+    buttons:
+      publish: "<span class='text-white'>You need to confirm your PubliCV account first. <br>Click <a class='text-primary bg-light font-weight-bold text-decoration-none' href='/users/confirmation/new'>here</a> to confirm</span>"


### PR DESCRIPTION
Issue:- #216 
When user creates an account on publiCV and **doesn't confirm** their account, they wont be able to **publish** their CV and will be redirected to a link, from where they can confirm their account and can publish their CV so that it will be visible openly.

https://user-images.githubusercontent.com/81285549/133414915-a8633bf3-4537-4ec9-a675-72d8c530c435.mp4



