### PR TITLE
Path after updating subdomain

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -52,6 +52,10 @@ module Users
       devise_parameter_sanitizer.permit(:account_update, keys: [:subdomain])
     end
 
+    def after_update_path_for(resource)
+      cv_section_path(resource.subdomain)
+    end
+
     # The path used after sign up.
     # def after_sign_up_path_for(resource)
     #   super(resource)


### PR DESCRIPTION
Issue:- #225
When a user update their account then they will be redirected to their CV page instead of homepage.

https://user-images.githubusercontent.com/81285549/136739956-8ec800c3-49ce-4c44-b03b-6d11f9801341.mp4

