### PR TITLE
Added edit buttons visibility.

### DIFF
--- a/app/helpers/cvs_helper.rb
+++ b/app/helpers/cvs_helper.rb
@@ -46,7 +46,7 @@ module CvsHelper
 
   # to show edit controls when Cv owner view it in edit mode
   def edit_mode?
-    (can? :update, @cv) && params[:subdomain] && params[:preview] != 't'
+    (can? :update, @cv) && params[:preview] != 't'
   end
 
   def cv_cache_key(cv)


### PR DESCRIPTION
Issue:- #261 
Made the edit buttons visible after making changes in CV without the need to reload the CV's show page.

https://user-images.githubusercontent.com/80153678/146540144-93b1c22b-1e9b-49da-80e5-7ff15713ef42.mp4

