### PR TITLE
Fixed the image edit button position

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,18 @@
 Rails:
   Enabled: true
 
+Rails/HasAndBelongsToMany:
+  Exclude:
+  - 'app/models/role.rb'
+  - 'app/models/user.rb'
+
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
 Metrics/LineLength:
   Max: 120
+  Exclude:
+  - 'config/initializers/rack_attack.rb'
 
 Metrics/MethodLength:
   Max: 15

--- a/app/helpers/cvs_helper.rb
+++ b/app/helpers/cvs_helper.rb
@@ -57,6 +57,10 @@ module CvsHelper
     end
   end
 
+  def cv_image_edit(cv)
+    cv.headshot_file_name.present? ? 'icon_size' : 'popup-text'
+  end
+
   private
 
   def get_period(start_date, end_date)

--- a/app/javascript/src/stylesheets/custom/common/base.scss
+++ b/app/javascript/src/stylesheets/custom/common/base.scss
@@ -323,13 +323,23 @@ nav {
 }
 .popup-text{
   position: absolute;
-  bottom: 0;
-  left: 63%;
+  top: 11.5rem;
+  left: 11.25rem;
+}
+.icon_size{
+  position: absolute;
+  top: 9.625rem;
+  left: 10.625rem;
 }
 @media only screen and (max-width: 768px) {
   .popup-text{
-    bottom: 0;
-    left: 170px;
+    top: 11.5rem;
+    left: 11.25rem;
+  }
+  .icon_size{
+    position: absolute;
+    top: 9.625rem;
+    left: 10.625rem;
   }
 }
 .edit-btn{

--- a/app/views/cvs/cv_sections/_intro.html.erb
+++ b/app/views/cvs/cv_sections/_intro.html.erb
@@ -46,7 +46,7 @@
         <div class="col-12 col-md-3 mb-2 mb-md-0 headshot-edit">
           <%= image_tag(@cv.headshot.url(:default), alt: "#{@cv.abbr_name} headshot", class: 'img-fluid') %>
           <% if edit_mode? %>
-            <%= link_to edit_cv_section_path(section: :headshot), remote: true, class: 'btn-cv btn-edit popup-text' do %>
+            <%= link_to edit_cv_section_path(section: :headshot), remote: true, class: "btn-cv btn-edit #{cv_image_edit(@cv)}" do %>
               <span class="badge rounded-circle p-2 edit-btn"><i class="icon-pencil"></i></span>
             <% end %>
           <% end %>

--- a/app/views/cvs/edit_modals/_headshot_form.html.erb
+++ b/app/views/cvs/edit_modals/_headshot_form.html.erb
@@ -15,7 +15,7 @@
           </div>
         </div>
         <div class="col-md-6 col-12 text-md-left text-center mb-2">
-          <button type='button' id='uploader' class="btn btn-primary rounded">Upload Photo <i class="icon-cloud-upload"></i></button>
+          <button type='button' id='uploader' class="btn btn-primary rounded mt-3 mt-md-0">Upload Photo <i class="icon-cloud-upload"></i></button>
         </div>
         <%= f.file_field :headshot, accept: 'image/jpeg, image/png', class: 'form-control form-control-lg d-none' %>
       </div>


### PR DESCRIPTION
Issue:- #305 
Fixed the image edit button position for mobile view and desktop view.
**1.**
![Screenshot from 2022-01-07 11-57-34](https://user-images.githubusercontent.com/80153678/148504495-1df412c0-11dc-45ee-b875-204a68daa451.png)

**2.**
![Screenshot from 2022-01-07 11-56-45](https://user-images.githubusercontent.com/80153678/148504502-85276e31-a31e-4fcb-a502-2f2ecfadf95b.png)

**3.**
![Screenshot from 2022-01-07 11-56-23](https://user-images.githubusercontent.com/80153678/148504503-ad97b8dd-8f27-4b53-be2a-6764534b1fd1.png)

**4.**
![Screenshot from 2022-01-07 11-55-58](https://user-images.githubusercontent.com/80153678/148504507-a46843d5-efa7-40b8-8c87-83e791fac214.png)
