### PR TITLE
Fixed user address privacy

### DIFF
--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -2,4 +2,13 @@ module LocationsHelper
   def api_token
     ENV['LOCATIONIQ_PUBLIC_KEY']
   end
+
+  def location_display(res)
+    a = ['city', 'region', 'country']
+    cc = []
+    a.each do |key|
+      cc << res.send(key.to_sym) if res.send(key.to_sym)
+    end
+    cc.join(', ')
+  end
 end

--- a/app/views/cvs/cv_sections/_intro.html.erb
+++ b/app/views/cvs/cv_sections/_intro.html.erb
@@ -11,8 +11,10 @@
           <% end %>
         </div>
         <h6 class="font-weight-normal"><%= birth_info_for(@cv) %></h6>
-        <% if @user.current_location.present? %>
-          <h6 class="font-weight-normal"><%= @user.current_location&.original_address %></h6>
+        <% if edit_mode? && @user.current_location.present? %>
+          <h6 class="font-weight-normal">
+            <%= location_display(@user.current_location) %>
+          </h6>
         <% end %>
 
         <div class="row mt-4">

--- a/app/views/cvs/edit_modals/_intro_form.html.erb
+++ b/app/views/cvs/edit_modals/_intro_form.html.erb
@@ -84,6 +84,7 @@
               <div class="form-group mb-5">
                 <%= location.label :original_address, t('content.main.cv.new.location.city'), for: "edit_cv_intro_address", class: 'text-muted d-block' %>
                 <%= location.text_field :original_address, autocomplete: 'off', class: 'form-control', id: "edit_cv_intro_address" %>
+                <label class="text-muted d-block mt-2 font-size-14 ml-3"><%= t('content.main.cv.new.location.example') %></label>
                 <div class="autocomplete-results position-absolute" id="edit_cv_intro_results">
                   <ul>
                   </ul>

--- a/app/views/searches/_results.html.erb
+++ b/app/views/searches/_results.html.erb
@@ -12,7 +12,7 @@
                 <p class="text-dark mb-0 font-size-14 text-right"><%= cv.updated_at&.strftime("%B %d, %Y") %></p>
                 <div class="d-flex">
                   <h6 class="text-dark pr-1"><%= result.abbr_name %></h6>
-                  <span class="text-muted font-size-14 pl-1"><%= result.original_address %></span>
+                  <span class="text-muted font-size-14 pl-1"><%= location_display(result) %></span>
                 </div>
                 <div>
                   <span class="badge badge-pill-cv badge-primary badge-primary-light text-primary font-weight-normal font-size-9 p-1 text-wrap text-left mt-2">

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -80,7 +80,8 @@ en:
             address: "Address *"
             radius: "Radius (in km)"
             title: "Add new location"
-            city: "Current City/Province"
+            city: "Current address"
+            example: "your address will always remain private, however it will help you to be visible to recruiters on the map"
         show:
           entries:
             description: "Description"

--- a/config/locales/app.it.yml
+++ b/config/locales/app.it.yml
@@ -81,7 +81,8 @@ it:
             address: "Città o indirizzo *"
             radius: "Raggio (in km), minimo 1"
             title: "Aggiungi Zona in cui cerchi lavoro"
-            city: "Città / Provincia attuale"
+            city: "Indirizzo di riferimento"
+            example: "Il tuo indirizzo resterà sempre privato, tuttavia ti sarà d'aiuto per essere visibile ai datori di lavoro sulla mappa"
         show:
           entries:
             description: "Descrizione"

--- a/db/migrate/20220218113712_update_searchable_cvs_to_version2.rb
+++ b/db/migrate/20220218113712_update_searchable_cvs_to_version2.rb
@@ -1,0 +1,5 @@
+class UpdateSearchableCvsToVersion2 < ActiveRecord::Migration[7.0]
+  def change
+    update_view :searchable_cvs, version: 2, revert_to_version: 1, materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -990,6 +990,9 @@ CREATE MATERIALIZED VIEW public.searchable_cvs AS
     min(locations.latitude) AS latitude,
     min(locations.longitude) AS longitude,
     min((locations.original_address)::text) AS original_address,
+    min((locations.city)::text) AS city,
+    min((locations.region)::text) AS region,
+    min((locations.country)::text) AS country,
     (((((((((setweight(to_tsvector('public.cv_en'::regconfig, COALESCE(cvs.about, ''::text)), 'B'::"char") || setweight(to_tsvector('public.cv_en'::regconfig, (COALESCE(cvs.skills, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('public.cv_en'::regconfig, (COALESCE(cvs.working_skills, ''::character varying))::text), 'A'::"char")) || setweight(to_tsvector('public.cv_en'::regconfig, (COALESCE(users.first_name, ''::character varying))::text), 'A'::"char")) || setweight(to_tsvector('public.cv_en'::regconfig, (COALESCE(users.last_name, ''::character varying))::text), 'A'::"char")) || setweight(to_tsvector('public.cv_en'::regconfig, COALESCE(string_agg(((locations.city)::text || (locations.country)::text), ' '::text), ''::text)), 'B'::"char")) || setweight(to_tsvector('public.cv_en'::regconfig, COALESCE(string_agg(((locations.geocoded_address)::text || (locations.original_address)::text), ' '::text), ''::text)), 'D'::"char")) || setweight(to_tsvector('public.cv_en'::regconfig, COALESCE(string_agg((((educations.degree)::text || educations.description) || (educations.school)::text), ' '::text), ''::text)), 'D'::"char")) || setweight(to_tsvector('public.cv_en'::regconfig, COALESCE(string_agg(((languages.language)::text || (languages.level)::text), ' '::text), ''::text)), 'C'::"char")) || setweight(to_tsvector('public.cv_en'::regconfig, COALESCE(string_agg((((experiences.company)::text || experiences.description) || (experiences.title)::text), ' '::text), ''::text)), 'C'::"char")) AS search_en_content_tsvector,
     (((((((((setweight(to_tsvector('public.cv_it'::regconfig, COALESCE(cvs.about, ''::text)), 'B'::"char") || setweight(to_tsvector('public.cv_it'::regconfig, (COALESCE(cvs.skills, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('public.cv_it'::regconfig, (COALESCE(cvs.working_skills, ''::character varying))::text), 'A'::"char")) || setweight(to_tsvector('public.cv_it'::regconfig, (COALESCE(users.first_name, ''::character varying))::text), 'A'::"char")) || setweight(to_tsvector('public.cv_it'::regconfig, (COALESCE(users.last_name, ''::character varying))::text), 'A'::"char")) || setweight(to_tsvector('public.cv_it'::regconfig, COALESCE(string_agg(((locations.city)::text || (locations.country)::text), ' '::text), ''::text)), 'B'::"char")) || setweight(to_tsvector('public.cv_it'::regconfig, COALESCE(string_agg(((locations.geocoded_address)::text || (locations.original_address)::text), ' '::text), ''::text)), 'D'::"char")) || setweight(to_tsvector('public.cv_it'::regconfig, COALESCE(string_agg((((educations.degree)::text || educations.description) || (educations.school)::text), ' '::text), ''::text)), 'D'::"char")) || setweight(to_tsvector('public.cv_it'::regconfig, COALESCE(string_agg(((languages.language)::text || (languages.level)::text), ' '::text), ''::text)), 'C'::"char")) || setweight(to_tsvector('public.cv_it'::regconfig, COALESCE(string_agg((((experiences.company)::text || experiences.description) || (experiences.title)::text), ' '::text), ''::text)), 'C'::"char")) AS search_it_content_tsvector
    FROM (((((public.cvs
@@ -1390,6 +1393,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220103100508'),
 ('20220104062550'),
 ('20220104062551'),
-('20220104105826');
+('20220104105826'),
+('20220218113712');
 
 

--- a/db/views/searchable_cvs_v02.sql
+++ b/db/views/searchable_cvs_v02.sql
@@ -1,0 +1,53 @@
+SELECT
+ cvs.id as cv_id,
+ users.id as user_id,
+ users.subdomain as subdomain,
+ users.first_name as first_name,
+ users.last_name as last_name,
+ MIN(locations.latitude) as latitude,
+ MIN(locations.longitude) as longitude,
+ MIN(locations.original_address) as original_address,
+ MIN(locations.city) as city,
+ MIN(locations.region) as region,
+ MIN(locations.country) as country,
+
+ (
+    setweight(to_tsvector('cv_en', coalesce(cvs.about , '')), 'B') ||
+    setweight(to_tsvector('cv_en', coalesce(cvs.skills , '')), 'B') ||
+    setweight(to_tsvector('cv_en', coalesce(cvs.working_skills , '')), 'A') ||
+    setweight(to_tsvector('cv_en', coalesce(users.first_name , '')), 'A') ||
+    setweight(to_tsvector('cv_en', coalesce(users.last_name , '')), 'A') ||
+    setweight(to_tsvector('cv_en', coalesce(STRING_AGG(locations.city || locations.country, ' '), '')), 'B') ||
+    setweight(to_tsvector('cv_en', coalesce(STRING_AGG(locations.geocoded_address || locations.original_address, ' '), '')), 'D') ||
+    setweight(to_tsvector('cv_en', coalesce(STRING_AGG(educations.degree || educations.description || educations.school, ' '), '')), 'D') ||
+    setweight(to_tsvector('cv_en', coalesce(STRING_AGG(languages.language || languages.level, ' '), '')), 'C') ||
+    setweight(to_tsvector('cv_en', coalesce(STRING_AGG(experiences.company || experiences.description || experiences.title, ' '), '')), 'C')
+ ) as search_en_content_tsvector,
+
+ (
+    setweight(to_tsvector('cv_it', coalesce(cvs.about , '')), 'B') ||
+    setweight(to_tsvector('cv_it', coalesce(cvs.skills , '')), 'B') ||
+    setweight(to_tsvector('cv_it', coalesce(cvs.working_skills , '')), 'A') ||
+    setweight(to_tsvector('cv_it', coalesce(users.first_name , '')), 'A') ||
+    setweight(to_tsvector('cv_it', coalesce(users.last_name , '')), 'A') ||
+    setweight(to_tsvector('cv_it', coalesce(STRING_AGG(locations.city || locations.country, ' '), '')), 'B') ||
+    setweight(to_tsvector('cv_it', coalesce(STRING_AGG(locations.geocoded_address || locations.original_address, ' '), '')), 'D') ||
+    setweight(to_tsvector('cv_it', coalesce(STRING_AGG(educations.degree || educations.description || educations.school, ' '), '')), 'D') ||
+    setweight(to_tsvector('cv_it', coalesce(STRING_AGG(languages.language || languages.level, ' '), '')), 'C') ||
+    setweight(to_tsvector('cv_it', coalesce(STRING_AGG(experiences.company || experiences.description || experiences.title, ' '), '')), 'C')
+ ) as search_it_content_tsvector
+
+FROM cvs
+
+INNER JOIN users ON users.id = cvs.user_id
+LEFT JOIN locations ON locations.user_id = users.id
+LEFT JOIN educations ON educations.cv_id = cvs.id
+LEFT JOIN languages ON languages.cv_id = cvs.id
+LEFT JOIN experiences ON experiences.cv_id = cvs.id
+
+WHERE 
+  cvs.published = true
+
+GROUP BY 
+  cvs.id, users.id
+


### PR DESCRIPTION
Issue: #367 
Added the check so that one user cannot view other user's location.
Updated the view for location display on CV show page and result page.

**1. Current address label**
![Screenshot from 2022-02-18 17-45-38](https://user-images.githubusercontent.com/80153678/154681521-6c2c9293-beb2-4f46-b5a0-6e6083fabf7b.png)

**2. Address on CV show page**
![Screenshot from 2022-02-18 17-48-41](https://user-images.githubusercontent.com/80153678/154681739-4fef3a20-d88a-4376-8073-ea22d6221478.png)

**3. If some other users visits CV show page.**
![Screenshot from 2022-02-18 17-46-26](https://user-images.githubusercontent.com/80153678/154681575-c8654f54-6301-4fa0-add7-aa74bf967fbb.png)
